### PR TITLE
Virtualenv finding on OS X

### DIFF
--- a/sublime_rope.py
+++ b/sublime_rope.py
@@ -468,8 +468,11 @@ class RopeNewProject(sublime_plugin.WindowCommand):
             error = '''Did not find a virtualenv at %s.
 Looking for path matching %s/Lib/site-packages'''
         else: # "linux", "osx"
+            cwd = os.getcwd()
+            os.chdir(self.proj_dir)
             site_p_dir = glob.glob(
                 os.path.join(path, "lib", "python*", "site-packages"))
+            os.chdir(cwd)
             error = '''Did not find a virtualenv at %s.
 Looking for path matching %s/lib/python*/site-packages'''
 


### PR DESCRIPTION
glob.glob() wasn't returning anything when I specified a relative path to SublimeRope when creating a new project because the working directory of Sublime Text 2's interpreter was the Package directory

This patch changes the directory to the project directory before doing the glob, then cd's back to the Package directory. It worked for me in my instance, I don't know if the way it is now is intentional or not.

Thanks!
