### PR TITLE
Add classmethods to globals for jump-to-globals list, similar to Eclipse...

### DIFF
--- a/SublimeRope.sublime-settings
+++ b/SublimeRope.sublime-settings
@@ -22,5 +22,11 @@
     "autoimport_modules": [],
     "pyflakes_linting": true,
     "complete_as_you_type": true,
-    "case_sensitive_completion": true
+    "case_sensitive_completion": true,
+
+    // If true, class properties/methods will be included in the 'jump-to-global' list,
+    // in addition to the module-level objects (similar to Eclipse's globals browser).  
+    // Requires a re-gen of the cache if this setting is changed. 
+    // Note: slightly shower since there are more objects to index
+    "include_classmethods_in_globals": false
 }

--- a/rope/contrib/autoimport.py
+++ b/rope/contrib/autoimport.py
@@ -99,10 +99,7 @@ class AutoImport(object):
         return result
 
     def get_classmethods_from_module(self, pymodule, name):
-        if isinstance(pymodule, pyobjects.PyDefinedObject):
-            attributes = pymodule._get_structural_attributes()
-        else:
-            attributes = pymodule.get_attributes()        
+        attributes = pymodule.get_attributes()        
         for cls in attributes.itervalues():
             if isinstance(cls, (pynames.AssignedName, pynames.DefinedName)):
                 pyobject = cls.pyobject

--- a/ropemate/__init__.py
+++ b/ropemate/__init__.py
@@ -79,22 +79,22 @@ class RopeContext(object):
         if self.tmpfile is not None:
             os.remove(self.tmpfile.name)
 
-    def build_cache(self):
+    def build_cache(self, class_methods=None):
         key = "building_cache_for_" + self.project.address
         sublime.set_timeout(
             lambda: self.view.set_status(key, "Building Rope cache ..."),
             0)
-        self.importer.generate_cache()
+        self.importer.generate_cache(class_methods=class_methods)
         sublime.set_timeout(
             lambda: self.view.erase_status(key),
             0)
 
-    def generate_modules_cache(self, modules):
+    def generate_modules_cache(self, modules, class_methods=None):
         key = "generate_modules_cache_for_" + self.project.address
         sublime.set_timeout(
             lambda: self.view.set_status(key, "Building Modules cache ..."),
             0)
-        self.importer.generate_modules_cache(modules)
+        self.importer.generate_modules_cache(modules, class_methods=class_methods)
         self.project.sync()
         sublime.set_timeout(
             lambda: self.view.erase_status(key),

--- a/sublime_rope.py
+++ b/sublime_rope.py
@@ -492,7 +492,9 @@ class SublimeRopeListener(sublime_plugin.EventListener):
         with ropemate.context_for(view) as context:
             # TODO: general solution to syncronizing SublimeRope and Rope (Rope's observers, keep one project open)
             context.project.pycore._invalidate_resource_cache(context.resource)
-            context.importer.generate_cache(resources=[context.resource])
+            class_methods = get_setting('include_classmethods_in_globals')
+            context.importer.generate_cache(resources=[context.resource],
+                                            class_methods=class_methods)
 
 
 # =============================================================================
@@ -575,9 +577,10 @@ class PythonJumpToGlobal(sublime_plugin.TextCommand):
 
         if choice is not -1:
             selected_global = self.names[choice]
+            class_methods = get_setting('include_classmethods_in_globals')
             with ropemate.context_for(self.view) as context:
                 self.locs = context.importer.get_name_locations(
-                    selected_global)
+                    selected_global, class_methods=class_methods)
                 self.locs = [loc_to_str(l) for l in self.locs]
 
                 if not self.locs:
@@ -830,13 +833,15 @@ class PythonGenerateModulesCache(sublime_plugin.TextCommand):
     Uses `generate_modules_cache` in a thread in order to build the cache'''
 
     class GenerateModulesCache(threading.Thread):
-        def __init__(self, ctx, modules):
+        def __init__(self, ctx, modules, class_methods):
             self.ctx = ctx
             self.modules = modules
+            self.class_methods = class_methods
             threading.Thread.__init__(self)
 
         def run(self):
-            self.ctx.importer.generate_modules_cache(self.modules)
+            self.ctx.importer.generate_modules_cache(self.modules,
+                                                     class_methods=self.class_methods)
             self.ctx.__exit__(None, None, None)
             self.ctx.building = False
 
@@ -849,8 +854,9 @@ class PythonGenerateModulesCache(sublime_plugin.TextCommand):
             ctx = ropemate.context_for(self.view)
             ctx.building = True
             ctx.__enter__()
+            class_methods = get_setting('include_classmethods_in_globals')
             thread = PythonGenerateModulesCache.GenerateModulesCache(
-                ctx, modules)
+                ctx, modules, class_methods)
             thread.start()
         else:
             sublime.error_message("Missing modules in configuration file")
@@ -862,13 +868,14 @@ class PythonRegenerateCache(sublime_plugin.TextCommand):
     might be neceessary.'''
 
     class RegenerateCacheThread(threading.Thread):
-        def __init__(self, ctx):
+        def __init__(self, ctx, class_methods):
             self.ctx = ctx
+            self.class_methods = class_methods
             threading.Thread.__init__(self)
 
         def run(self):
             self.ctx.importer.clear_cache()
-            self.ctx.build_cache()
+            self.ctx.build_cache(class_methods=self.class_methods)
             self.ctx.__exit__(None, None, None)
             self.ctx.building = False
 
@@ -877,7 +884,8 @@ class PythonRegenerateCache(sublime_plugin.TextCommand):
         ctx.building = True
         # we have to enter on main, but build on worker thread
         ctx.__enter__()
-        thread = PythonRegenerateCache.RegenerateCacheThread(ctx)
+        class_methods = get_setting('include_classmethods_in_globals')
+        thread = PythonRegenerateCache.RegenerateCacheThread(ctx, class_methods)
         thread.start()
 
 


### PR DESCRIPTION
You may or may not want this, but I was missing how Eclipse's Globals browser also included classmethod definitions in its Jump-To-Globals list, e.g.

```
class Foo(object):
    def bar(self): pass
    def baz(self): pass
```

would include

```
Foo
bar
baz
```

as navigable items in the jump-to-global list

Also added a settings key to enable/disable this behavior, since it slows the search slightly (more objects to index)
