### PR TITLE
Autoimport adds import below class definition if it has an import right above it

### DIFF
--- a/rope/contrib/autoimport.py
+++ b/rope/contrib/autoimport.py
@@ -126,7 +126,7 @@ class AutoImport(object):
 
     def find_insertion_line(self, code):
         """Guess at what line the new import should be inserted"""
-        match = re.search(r'^(def|class)\s+', code)
+        match = re.search(r'^(def|class)\s+', code, re.M)
         if match is not None:
             code = code[:match.start()]
         try:
@@ -140,7 +140,7 @@ class AutoImport(object):
         module_imports.add_import(importinfo)
         code = module_imports.get_changed_source()
         offset = code.index(testmodname)
-        lineno = code.count('\n', 0, offset) + 1
+        lineno = code.count('\n', 0, offset)
         return lineno
 
     def update_resource(self, resource, underlined=None):

--- a/sublime_rope.py
+++ b/sublime_rope.py
@@ -235,7 +235,7 @@ class AutoImport(threading.Thread):
                 all_lines = self.view.lines(
                     sublime.Region(0, self.view.size()))
                 line_no = context.importer.find_insertion_line(context.input)
-                insert_import_str = "from %s import %s\n" % (module, name)
+                insert_import_str = "\nfrom %s import %s\n" % (module, name)
                 existing_imports_str = self.view.substr(
                     sublime.Region(all_lines[0].a, all_lines[line_no - 1].b))
 


### PR DESCRIPTION
For example, after auto-import

``` python
import ...

import logging
class Foo(object):
      bar = datetime.datetime.utcnow()
```

becomes

``` python
import ...

import logging
class Foo(object):
import datetime
      bar = datetime.datetime.utcnow()
```

Due to the offset + 1 in autoimport.py.  Removed the +1 and changed it to a '\n' before the import statement, so that `import datetime` moves above `class Foo(object)`

Also fixed a regex bug that wasn't finding the first class/def since re.MULTILINE was not specified (it was always processing the whole file)
