### PR TITLE
Autoimport inserts at position 1 on failure, which could be in the middle of a module docstring

### DIFF
--- a/rope/contrib/autoimport.py
+++ b/rope/contrib/autoimport.py
@@ -132,7 +132,7 @@ class AutoImport(object):
         try:
             pymodule = self.project.pycore.get_string_module(code)
         except exceptions.ModuleSyntaxError:
-            return 1
+            return 0
         testmodname = '__rope_testmodule_rope'
         importinfo = importutils.NormalImport(((testmodname, None),))
         module_imports = importutils.get_module_imports(


### PR DESCRIPTION
For example:

``` python
"""
    This is a module
"""
foo = datetime.datetime.utcnow()
```

becomes

``` python
"""
import datetime
    This is a module
"""
foo = datetime.datetime.utcnow()
```

Changing it to 0 ensures it is put at the absolute top of the file
