### PR TITLE
Fix manual invocation

### DIFF
--- a/sublime_rope.py
+++ b/sublime_rope.py
@@ -378,7 +378,7 @@ class SublimeRopeListener(sublime_plugin.EventListener):
         if (
             not view.match_selector(locations[0], 'source.python') or
             not (self.complete_as_you_type) or
-            SublimeRopeListener.user_requested
+            not SublimeRopeListener.user_requested
         ):
             return []
 


### PR DESCRIPTION
Looks like a "not" was missing from on_query_completion.

To reproduce the bug this fixes:
1) Set keybinding: {"keys": ["ctrl+shift+space"], "command": "python_manual_completion_request"}
2) Set option "complete_as_you_type" to false
3) Create new python file and type:

import os
os.[[ctrl+shift+space]] <--- and rope is not invoked

This is because SublimeRopeListener.user_requested was set to True, and will never pass the first "if" test in on_query_completions, and as far as I can tell no other function will set user_requested to False.  Now that I think about it, it seems calling PythonManualCompletionRequest actually completely breaks autocompletion permanently until a) the plugin is reloaded or b) ST2 is restarted.  So this fixes that too I guess? :)
