### PR TITLE
Add python_manual_completion_request command

### DIFF
--- a/SublimeRope.sublime-commands
+++ b/SublimeRope.sublime-commands
@@ -50,5 +50,9 @@
     {
         "caption": "Rope: Organize Imports",
         "command": "python_organize_imports"
+    },
+    {
+        "caption": "Rope: Manual Completion",
+        "command": "python_manual_completion_request"
     }
 ]


### PR DESCRIPTION
The PythonManualCompletionRequest text command wasn't exposed in the SublimeRope.sublime-commands file, so it was impossible to bind it to a keyboard shortcut.
